### PR TITLE
GITHUB TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
   build_test_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'
 
@@ -35,4 +35,4 @@ jobs:
         run: dotnet pack --configuration Release --output . --include-source -p:PackageID=Dte.Common -p:PackageVersion=${{ steps.version.outputs.version-without-v }}
       
       - name: Dotnet Nuget push
-        run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_PACKAGE_TOKEN }} --source https://nuget.pkg.github.com/pa-nihr-crn/index.json --skip-duplicate
+        run: dotnet nuget push *.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/pa-nihr-crn/index.json --skip-duplicate

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,10 +8,10 @@ jobs:
   build_test_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'
 
@@ -32,4 +32,4 @@ jobs:
         run: dotnet pack --configuration Release --output . --include-source -p:PackageID=Dte.Common -p:PackageVersion=$(date +'%Y%m%d.%H%M%S')-preview
 
       - name: Dotnet Nuget push
-        run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_PACKAGE_TOKEN }} --source https://nuget.pkg.github.com/pa-nihr-crn/index.json --skip-duplicate
+        run: dotnet nuget push *.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/pa-nihr-crn/index.json --skip-duplicate


### PR DESCRIPTION
Replacing NUGET_PACKAGE_TOKEN secret with GITHUB_TOKEN to use Github App authentication to retrieve packages in all workflows